### PR TITLE
Add wad.py, which handles the data contained in a WAD file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ cython_debug/
 
 # Allows me to keep TMD files in my repository folder for testing without accidentally publishing them
 *.tmd
+*.wad

--- a/src/libWiiPy/commonkeys.py
+++ b/src/libWiiPy/commonkeys.py
@@ -1,4 +1,5 @@
-# "commonkeys.py" from libWiiPy by NinjaCheetah
+# "commonkeys.py" from libWiiPy by NinjaCheetah & Contributors
+# https://github.com/NinjaCheetah/libWiiPy
 
 default_key = 'ebe42a225e8593e448d9c5457381aaf7'
 korean_key = '63b82bb4f4614e2e13f2fefbba4c9b7e'

--- a/src/libWiiPy/tmd.py
+++ b/src/libWiiPy/tmd.py
@@ -1,4 +1,5 @@
 # "tmd.py" from libWiiPy by NinjaCheetah
+#
 # See https://wiibrew.org/wiki/Title_metadata for details about the TMD format
 
 import binascii

--- a/src/libWiiPy/tmd.py
+++ b/src/libWiiPy/tmd.py
@@ -1,7 +1,9 @@
-# "tmd.py" from libWiiPy by NinjaCheetah
+# "tmd.py" from libWiiPy by NinjaCheetah & Contributors
+# https://github.com/NinjaCheetah/libWiiPy
 #
 # See https://wiibrew.org/wiki/Title_metadata for details about the TMD format
 
+import io
 import binascii
 from dataclasses import dataclass
 from typing import List
@@ -18,7 +20,7 @@ class ContentRecord:
 
 
 class TMD:
-    """Creates a TMD object that can be used to read all the data contained in a TMD."""
+    """Creates a TMD object to parse a TMD file to retrieve information about a title."""
     def __init__(self, tmd):
         self.tmd = tmd
         self.sig_type: int
@@ -41,64 +43,64 @@ class TMD:
         self.boot_index: int
         self.content_record: List[ContentRecord]
         # Load data from TMD file
-        with open(tmd, "rb") as tmdfile:
+        with io.BytesIO(tmd) as tmddata:
             # Signing certificate issuer
-            tmdfile.seek(0x140)
-            self.issuer = tmdfile.read(64)
+            tmddata.seek(0x140)
+            self.issuer = tmddata.read(64)
             # TMD version, seems to usually be 0, but I've seen references to other numbers
-            tmdfile.seek(0x180)
-            self.version = int.from_bytes(tmdfile.read(1))
+            tmddata.seek(0x180)
+            self.version = int.from_bytes(tmddata.read(1))
             # TODO: label
-            tmdfile.seek(0x181)
-            self.ca_crl_version = tmdfile.read(1)
+            tmddata.seek(0x181)
+            self.ca_crl_version = tmddata.read(1)
             # TODO: label
-            tmdfile.seek(0x182)
-            self.signer_crl_version = tmdfile.read(1)
+            tmddata.seek(0x182)
+            self.signer_crl_version = tmddata.read(1)
             # If this is a vWii title or not
-            tmdfile.seek(0x183)
-            self.vwii = int.from_bytes(tmdfile.read(1))
+            tmddata.seek(0x183)
+            self.vwii = int.from_bytes(tmddata.read(1))
             # TID of the IOS to use for the title, set to 0 if this title is the IOS, set to boot2 version if boot2
-            tmdfile.seek(0x184)
-            ios_version_bin = tmdfile.read(8)
+            tmddata.seek(0x184)
+            ios_version_bin = tmddata.read(8)
             ios_version_hex = binascii.hexlify(ios_version_bin)
             self.ios_tid = str(ios_version_hex.decode())
             # Get IOS version based on TID
             self.ios_version = int(self.ios_tid[-2:], 16)
             # Title ID of the title
-            tmdfile.seek(0x18C)
-            title_id_bin = tmdfile.read(8)
+            tmddata.seek(0x18C)
+            title_id_bin = tmddata.read(8)
             title_id_hex = binascii.hexlify(title_id_bin)
             self.title_id = str(title_id_hex.decode())
             # Type of content
-            tmdfile.seek(0x194)
-            content_type_bin = tmdfile.read(4)
+            tmddata.seek(0x194)
+            content_type_bin = tmddata.read(4)
             content_type_hex = binascii.hexlify(content_type_bin)
             self.content_type = str(content_type_hex.decode())
             # Publisher of the title
-            tmdfile.seek(0x198)
-            self.group_id = tmdfile.read(2)
+            tmddata.seek(0x198)
+            self.group_id = tmddata.read(2)
             # Region of the title, 0 = JAP, 1 = USA, 2 = EUR, 3 = NONE, 4 = KOR
-            tmdfile.seek(0x19C)
-            region_hex = tmdfile.read(2)
+            tmddata.seek(0x19C)
+            region_hex = tmddata.read(2)
             self.region = int.from_bytes(region_hex)
             # TODO: figure this one out
-            tmdfile.seek(0x19E)
-            self.ratings = tmdfile.read(16)
+            tmddata.seek(0x19E)
+            self.ratings = tmddata.read(16)
             # Access rights of the title; DVD-video access and AHBPROT
-            tmdfile.seek(0x1D8)
-            self.access_rights = tmdfile.read(4)
+            tmddata.seek(0x1D8)
+            self.access_rights = tmddata.read(4)
             # Calculate the version number by multiplying 0x1DC by 256 and adding 0x1DD
-            tmdfile.seek(0x1DC)
-            title_version_high = int.from_bytes(tmdfile.read(1)) * 256
-            tmdfile.seek(0x1DD)
-            title_version_low = int.from_bytes(tmdfile.read(1))
+            tmddata.seek(0x1DC)
+            title_version_high = int.from_bytes(tmddata.read(1)) * 256
+            tmddata.seek(0x1DD)
+            title_version_low = int.from_bytes(tmddata.read(1))
             self.title_version = title_version_high + title_version_low
             # The number of contents listed in the TMD
-            tmdfile.seek(0x1DE)
-            self.num_contents = int.from_bytes(tmdfile.read(2))
+            tmddata.seek(0x1DE)
+            self.num_contents = int.from_bytes(tmddata.read(2))
             # Content index in content list that contains the boot file
-            tmdfile.seek(0x1E0)
-            self.boot_index = tmdfile.read(2)
+            tmddata.seek(0x1E0)
+            self.boot_index = tmddata.read(2)
 
     def get_title_id(self):
         """Returns the TID of the TMD's associated title."""

--- a/src/libWiiPy/wad.py
+++ b/src/libWiiPy/wad.py
@@ -20,10 +20,10 @@ class ContentRecord:
 
 class wadHeader:
     """Break down 32 byte WAD header."""
-    def __init__(self, wadhdr):
-        self.wadhdr = wadhdr
+    def __init__(self, wad):
+        self.wad = wad
         self.wad_hdr_size: int
-        self.wad_type: int
+        self.wad_type: str
         self.wad_version: int
         # Sizes
         self.wad_cert_size: int
@@ -50,7 +50,7 @@ class wadHeader:
             self.wad_hdr_size = wadfile.read(4)
             # WAD type
             wadfile.seek(0x04)
-            self.wad_type = wadfile.read(2)
+            self.wad_type = str(wadfile.read(2).decode())
             # WAD version
             wadfile.seek(0x06)
             self.wad_version = wadfile.read(2)
@@ -75,28 +75,31 @@ class wadHeader:
             #====================================================================================
             # Calculate file offsets from sizes
             #====================================================================================
-            self.wad_cert_offset + self.wad_hdr_size
+            self.wad_cert_offset = self.wad_hdr_size
             # I've never seen crl used (don't even know what it's for) but still calculating in case...
-            self.wad_crl_offset + self.wad_cert_offset + self.wad_cert_size
-            self.wad_tik_offset + self.wad_crl_offset + self.wad_crl_size
-            self.wad_tmd_offset + self.wad_tik_offset + self.wad_tik_size
-            self.wad_app_offset + self.wad_tmd_offset + self.wad_tmd_size
+            self.wad_crl_offset = self.wad_cert_offset + self.wad_cert_size
+            self.wad_tik_offset = self.wad_crl_offset + self.wad_crl_size
+            self.wad_tmd_offset = self.wad_tik_offset + self.wad_tik_size
+            self.wad_app_offset = self.wad_tmd_offset + self.wad_tmd_size
             # Same with meta. If private Nintendo tools calculate these then maaaaaybe we should too.
-            self.wad_meta_offset + self.wad_app_offset + self.wad_app_size
+            self.wad_meta_offset = self.wad_app_offset + self.wad_app_size
 
     def get_cert_region(self):
-        """Returns the offset and size for the cert"""
+        """Returns the offset and size for the cert."""
         return self.wad_cert_offset, self.wad_cert_size
 
     def get_ticket_region(self):
-        """Returns the offset and size for the ticket"""
+        """Returns the offset and size for the ticket."""
         return self.wad_tik_offset, self.wad_tik_size
 
     def get_tmd_region(self):
-        """Returns the offset and size for the TMD"""
+        """Returns the offset and size for the TMD."""
         return self.wad_tmd_offset, self.wad_tmd_size
 
     def get_app_region(self):
-        """Returns the offset and size for the app"""
+        """Returns the offset and size for the app."""
         return self.wad_app_offset, self.wad_tmd_size
-      
+
+    def get_wad_type(self):
+        """Returns the type of the WAD. This is 'Is' unless the WAD contains boot2 where it is 'ib'."""
+        return self.wad_type

--- a/src/libWiiPy/wad.py
+++ b/src/libWiiPy/wad.py
@@ -1,0 +1,102 @@
+# Project: libWiiPy by NinjaCheetah
+# File: wad.py by rmc
+#
+# See https://wiibrew.org/wiki/WAD_files for details about the WAD format
+
+import binascii
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class ContentRecord:
+    """Creates a content record object that contains the details of a content contained in a title."""
+    cid: int  # Content ID
+    index: int  # Index in the list of contents
+    content_type: int  # normal: 0x0001; dlc: 0x4001; shared: 0x8001
+    content_size: int
+    content_hash: bytearray  # SHA1 hash content
+
+
+class wadHeader:
+    """Break down 32 byte WAD header."""
+    def __init__(self, wadhdr):
+        self.wadhdr = wadhdr
+        self.wad_hdr_size: int
+        self.wad_type: int
+        self.wad_version: int
+        # Sizes
+        self.wad_cert_size: int
+        self.wad_crl_size: int
+        self.wad_tik_size: int
+        self.wad_tmd_size: int
+        self.wad_app_size: int  # Note that this is the size of the app region. This is each individual app file bundled together.
+        self.wad_meta_size: int
+        # Offsets
+        self.wad_cert_offset: int
+        self.wad_crl_offset: int
+        self.wad_tik_offset: int
+        self.wad_tmd_offset: int
+        self.wad_app_offset: int
+        self.wad_meta_offset: int
+        #self.content_record: List[ContentRecord]
+        # Load header data from WAD file
+        with open(wad, "rb") as wadfile:
+            #====================================================================================
+            # Get the sizes of each data region contained within the WAD. Sorry for mid code!
+            #====================================================================================
+            # Header length. Always seems to be 32 so we'll ignore it for now.
+            wadfile.seek(0x0)
+            self.wad_hdr_size = wadfile.read(4)
+            # WAD type
+            wadfile.seek(0x04)
+            self.wad_type = wadfile.read(2)
+            # WAD version
+            wadfile.seek(0x06)
+            self.wad_version = wadfile.read(2)
+            # WAD cert size
+            wadfile.seek(0x08)
+            self.wad_cert_size = wadfile.read(4)
+            # WAD crl size
+            wadfile.seek(0x0c)
+            self.wad_crl_size = wadfile.read(4)
+            # WAD ticket size
+            wadfile.seek(0x10)
+            self.wad_tik_size = wadfile.read(4)
+            # WAD TMD size
+            wadfile.seek(0x14)
+            self.wad_tmd_size = wadfile.read(4)
+            # WAD app size
+            wadfile.seek(0x18)
+            self.wad_app_size = wadfile.read(4)
+            # Publisher of the title
+            wadfile.seek(0x1c)
+            self.wad_meta_size = wadfile.read(4)
+            #====================================================================================
+            # Calculate file offsets from sizes
+            #====================================================================================
+            self.wad_cert_offset + self.wad_hdr_size
+            # I've never seen crl used (don't even know what it's for) but still calculating in case...
+            self.wad_crl_offset + self.wad_cert_offset + self.wad_cert_size
+            self.wad_tik_offset + self.wad_crl_offset + self.wad_crl_size
+            self.wad_tmd_offset + self.wad_tik_offset + self.wad_tik_size
+            self.wad_app_offset + self.wad_tmd_offset + self.wad_tmd_size
+            # Same with meta. If private Nintendo tools calculate these then maaaaaybe we should too.
+            self.wad_meta_offset + self.wad_app_offset + self.wad_app_size
+
+    def get_cert_region(self):
+        """Returns the offset and size for the cert"""
+        return self.wad_cert_offset, self.wad_cert_size
+
+    def get_ticket_region(self):
+        """Returns the offset and size for the ticket"""
+        return self.wad_tik_offset, self.wad_tik_size
+
+    def get_tmd_region(self):
+        """Returns the offset and size for the TMD"""
+        return self.wad_tmd_offset, self.wad_tmd_size
+
+    def get_app_region(self):
+        """Returns the offset and size for the app"""
+        return self.wad_app_offset, self.wad_tmd_size
+      


### PR DESCRIPTION
wad.py allows for reading the header of a WAD file to determine the location of each of its sections, and exposes functions to allow you to retrieve those sections once a WAD is loaded. This allows for the first step of extraction to be completed, because the `.cert`, `.tik`, `.tmd`, and encrypted content bundle can now all be extracted. This means that it closes #2 and is the first step towards full WAD file extraction!

Thanks for all the help Lillian!