### PR TITLE
Extract individual app contents from WAD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,9 @@ cython_debug/
 # Allows me to keep TMD files in my repository folder for testing without accidentally publishing them
 *.tmd
 *.wad
+out_prod/
+remakewad.pl
+
+# Also awful macOS files
+*._*
+*.DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [project]
 name = "libWiiPy"
-version = "0.0.1"
+version = "0.1.0"
 authors = [
-  { name="NinjaCheetah", email="ninjacheetah@ncxprogramming.com" },
+    { name="NinjaCheetah", email="ninjacheetah@ncxprogramming.com" },
+    { name="Lillian Skinner", email="lillian@randommeaninglesscharacters.com" }
 ]
 description = "A Wii-related library for Python"
 readme = "README.md"

--- a/src/libWiiPy/tmd.py
+++ b/src/libWiiPy/tmd.py
@@ -108,7 +108,7 @@ class TMD:
             while i < self.num_contents:
                 tmddata.seek(0x1E4 + (36 * i))
                 self.content_record_hdr = struct.unpack(">LHH4x4s20s", tmddata.read(36))
-                self.content_record.append(ContentRecord(self.content_record_hdr[0], self.content_record_hdr[1], self.content_record_hdr[2], self.content_record_hdr[3], self.content_record_hdr[4]))
+                self.content_record.append(ContentRecord(int(self.content_record_hdr[0]), int(self.content_record_hdr[1]), int(self.content_record_hdr[2]), int.from_bytes(self.content_record_hdr[3]), binascii.hexlify(self.content_record_hdr[4]).decode()))
                 i += 1
 
     def get_title_id(self):
@@ -195,4 +195,7 @@ class TMD:
 
     def get_content_records(self, record):
         """Returns all values for the specified content record."""
-        return  self.content_record[record].cid, self.content_record[record].index, self.content_record[record].content_type, self.content_record[record].content_size, self.content_record[record].content_hash
+        if record <= self.num_contents:
+            return  self.content_record[record].cid, self.content_record[record].index, self.content_record[record].content_type, self.content_record[record].content_size, self.content_record[record].content_hash
+        else:
+            return      

--- a/src/libWiiPy/tmd.py
+++ b/src/libWiiPy/tmd.py
@@ -198,5 +198,5 @@ class TMD:
         if record < self.num_contents:
             return self.content_records[record]
         else:
-            raise IndexError("Invalid content record! TMD lists '" + str(self.num_contents) +
+            raise IndexError("Invalid content record! TMD lists '" + str(self.num_contents - 1) +
                              "' contents but index was '" + str(record) + "'!")


### PR DESCRIPTION
`tmd.py` can now retrieve data from the content records at `0x1E4` for extracting all app contents. Note that these are still encrypted and will need to be decrypted with the common key.

Closes #1.