### PR TITLE
Add netcard key

### DIFF
--- a/src/libWiiPy/title/commonkeys.py
+++ b/src/libWiiPy/title/commonkeys.py
@@ -6,13 +6,14 @@ import binascii
 common_key = 'ebe42a225e8593e448d9c5457381aaf7'
 korean_key = '63b82bb4f4614e2e13f2fefbba4c9b7e'
 vwii_key = '30bfc76e7c19afbb23163330ced7c28d'
+netcard_key = '67458b6bc6237b3269983c6473483366'
 
 
 def get_common_key(common_key_index) -> bytes:
     """
     Gets the specified Wii Common Key based on the index provided.
 
-    Possible values for common_key_index: 0: Common Key, 1: Korean Key, 2: vWii Key
+    Possible values for common_key_index: 0: Common Key, 1: Korean Key, 2: vWii Key, 3: Netcard Key
 
     Parameters
     ----------
@@ -31,6 +32,8 @@ def get_common_key(common_key_index) -> bytes:
             common_key_bin = binascii.unhexlify(korean_key)
         case 2:
             common_key_bin = binascii.unhexlify(vwii_key)
+        case 3:
+            common_key_bin = binascii.unhexlify(netcard_key)
         case _:
             raise ValueError("The common key index provided, " + str(common_key_index) + ", does not exist.")
     return common_key_bin


### PR DESCRIPTION
There are netcard WADs in `paladin/NetCardWads` (gigaleaks) that use a different key. There may be others as well.